### PR TITLE
Login alert

### DIFF
--- a/app/components/AdvocateLogin.jsx
+++ b/app/components/AdvocateLogin.jsx
@@ -4,6 +4,7 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 
 import { login } from '../reducers/auth'
+import { clearLoginError } from '../reducers/loginError'
 
 /* ----------------- COMPONENT ------------------ */
 
@@ -12,6 +13,7 @@ class AdvocateLogin extends Component {
   componentDidMount () {
     // To handle material design styling on inputs
     componentHandler.upgradeDom()
+    this.props.clearLoginError()
   }
 
   render () {
@@ -37,13 +39,15 @@ class AdvocateLogin extends Component {
                   <button className="mdl-button mdl-js-button mdl-button--raised mdl-button--accent">
                     Submit
                   </button>
-                </div>
-                {
-                  this.props.loginError &&
-                  (<div>
-                    Name / Password Invalid
-                  </div>)
-                }
+                  </div>
+                  {
+                    this.props.loginError &&
+                      (
+                        <div className="login-error">
+                          <p>Login Failed</p>
+                        </div>
+                      )
+                    }
               </form>
             </div>
           </div>
@@ -65,6 +69,9 @@ const mapDispatchToProps = dispatch => {
   return {
     login: (username, password) => {
       dispatch(login(username, password))
+    },
+    clearLoginError: () => {
+      dispatch(clearLoginError())
     }
   }
 }

--- a/app/components/AdvocateLogin.jsx
+++ b/app/components/AdvocateLogin.jsx
@@ -25,11 +25,11 @@ class AdvocateLogin extends Component {
             <div className="mdl-card__supporting-text">
               <form action="#" onSubmit={evt => {
                 evt.preventDefault()
-                console.log(this.props.login(evt.target.name.value, evt.target.password.value))
+                this.props.login(evt.target.name.value, evt.target.password.value)
               } }>
                 <div className="mdl-textfield mdl-js-textfield">
                   <input className="mdl-textfield__input" type="text" id="name" />
-                  <label className="mdl-textfield__label" htmlFor="name">Name</label>
+                  <label className="mdl-textfield__label" htmlFor="name">E-mail</label>
                 </div>
                 <div className="mdl-textfield mdl-js-textfield">
                   <input className="mdl-textfield__input" type="password" id="password" />

--- a/app/components/AdvocateLogin.jsx
+++ b/app/components/AdvocateLogin.jsx
@@ -2,7 +2,6 @@
 
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { browserHistory } from 'react-router'
 
 import { login } from '../reducers/auth'
 
@@ -24,7 +23,7 @@ class AdvocateLogin extends Component {
             <div className="mdl-card__supporting-text">
               <form action="#" onSubmit={evt => {
                 evt.preventDefault()
-                this.props.login(evt.target.name.value, evt.target.password.value)
+                console.log(this.props.login(evt.target.name.value, evt.target.password.value))
               } }>
                 <div className="mdl-textfield mdl-js-textfield">
                   <input className="mdl-textfield__input" type="text" id="name" />
@@ -39,6 +38,12 @@ class AdvocateLogin extends Component {
                     Submit
                   </button>
                 </div>
+                {
+                  this.props.loginError &&
+                  (<div>
+                    Name / Password Invalid
+                  </div>)
+                }
               </form>
             </div>
           </div>
@@ -50,13 +55,18 @@ class AdvocateLogin extends Component {
 
 /* ----------------- CONTAINER ------------------ */
 
+const mapStateToProps = state => {
+  return {
+    loginError: state.loginError
+  }
+}
+
 const mapDispatchToProps = dispatch => {
   return {
     login: (username, password) => {
       dispatch(login(username, password))
-      browserHistory.push('/available-dashboard')
     }
   }
 }
 
-export default connect(null, mapDispatchToProps)(AdvocateLogin)
+export default connect(mapStateToProps, mapDispatchToProps)(AdvocateLogin)

--- a/app/reducers/auth.jsx
+++ b/app/reducers/auth.jsx
@@ -3,7 +3,6 @@ import { dropIssues } from './issues'
 import { dropVolunteers } from './volunteers'
 import { dropAdvocates } from './advocates'
 import { browserHistory } from 'react-router'
-
 import { setLoginError } from './loginError'
 
 const reducer = (state = null, action) => {

--- a/app/reducers/auth.jsx
+++ b/app/reducers/auth.jsx
@@ -2,6 +2,9 @@ import axios from 'axios'
 import { dropIssues } from './issues'
 import { dropVolunteers } from './volunteers'
 import { dropAdvocates } from './advocates'
+import { browserHistory } from 'react-router'
+
+import { setLoginError } from './loginError'
 
 const reducer = (state = null, action) => {
   switch (action.type) {
@@ -20,8 +23,8 @@ export const login = (username, password) =>
   dispatch =>
     axios.post('/api/auth/local/login',
       { username, password })
-      .then(() => dispatch(whoami()))
-      .catch(() => dispatch(whoami()))
+      .then(() => browserHistory.push('/available-dashboard'))
+      .catch(() => dispatch(setLoginError(true)))
 
 export const logout = () =>
   dispatch =>

--- a/app/reducers/index.jsx
+++ b/app/reducers/index.jsx
@@ -4,7 +4,8 @@ const rootReducer = combineReducers({
   auth: require('./auth').default,
   issues: require('./issues').default,
   volunteers: require('./volunteers').default,
-  advocates: require('./advocates').default
+  advocates: require('./advocates').default,
+  loginError: require('./loginError').default
 })
 
 export default rootReducer

--- a/app/reducers/loginError.jsx
+++ b/app/reducers/loginError.jsx
@@ -1,15 +1,19 @@
 
+const SET_ERROR = 'SET_ERROR'
 export const setLoginError = errorState => ({
   type: SET_ERROR,
-  errorState
+  errorState  // boolean
 })
 
-const SET_ERROR = 'SET_ERROR'
+export const clearLoginError = () => ({
+  type: SET_ERROR,
+  errorState: false
+})
+
 const reducer = (state = false, action) => {
   switch (action.type) {
     case SET_ERROR:
-      const newState = action.errorState
-      return newState
+      return action.errorState
     default:
       return state
   }

--- a/app/reducers/loginError.jsx
+++ b/app/reducers/loginError.jsx
@@ -1,0 +1,18 @@
+
+export const setLoginError = errorState => ({
+  type: SET_ERROR,
+  errorState
+})
+
+const SET_ERROR = 'SET_ERROR'
+const reducer = (state = false, action) => {
+  switch (action.type) {
+    case SET_ERROR:
+      const newState = action.errorState
+      return newState
+    default:
+      return state
+  }
+}
+
+export default reducer

--- a/public/style.css
+++ b/public/style.css
@@ -30,6 +30,18 @@ a, a:hover {
   margin: 0;
 }
 
+.login-error {
+  margin-top: 1em;
+  background-color: red;
+  border-radius: 5px;
+}
+
+.login-error p {
+  margin-bottom: 0;
+  color: white;
+  padding: 1em;
+}
+
 /*Make container for main content*/
 .page-content {
   margin-left: 25px;


### PR DESCRIPTION
fixes #21 

A failed login still results in a 400 being sent from the server, which is then caught to display the alert window. We had talked about refactoring this away from the 'catch,' but then I started to reconsider, thinking that I like it the way it is. The 400 is meant for a bad login after all, isn't it?

I created a 'loginError' reducer. I was thinking  you might want a key added to the auth reducer instead maybe? Let me know what you think. I was thinking the loginError could actually be refactored to a more-general 'errors' reducer, which might be handy.

I also have very minimal styling and no animations at all for the moment. 


<img width="377" alt="screen shot 2017-02-27 at 6 07 04 pm" src="https://cloud.githubusercontent.com/assets/22568379/23384166/a94d4314-fd17-11e6-88f8-11bff4c889a9.png">
